### PR TITLE
Remove uniqueness validator for paranoid models by default

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -174,16 +174,3 @@ end
 
 
 require 'paranoia/rspec' if defined? RSpec
-
-module ActiveRecord
-  module Validations
-    class UniquenessValidator < ActiveModel::EachValidator
-      protected
-      def build_relation_with_paranoia(klass, table, attribute, value)
-        relation = build_relation_without_paranoia(klass, table, attribute, value)
-        relation.and(klass.arel_table[klass.paranoia_column].eq(nil))
-      end
-      alias_method_chain :build_relation, :paranoia
-    end
-  end
-end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -435,15 +435,9 @@ class ParanoiaTest < Test::Unit::TestCase
     # essentially, we're just ensuring that this doesn't crash
   end
 
-  def test_validates_uniqueness_only_checks_non_deleted_records
+  def test_validates_uniqueness_checks_all_records
     a = Employer.create!(name: "A")
     a.destroy
-    b = Employer.new(name: "A")
-    assert b.valid?
-  end
-
-  def test_validates_uniqueness_still_works_on_non_deleted_records
-    a = Employer.create!(name: "A")
     b = Employer.new(name: "A")
     refute b.valid?
   end


### PR DESCRIPTION
The validator breaks existing behavior.

from this upstream PR for rails 4
https://github.com/rubysherpas/paranoia/pull/277/files

and this issue:
https://github.com/rubysherpas/paranoia/issues/276
